### PR TITLE
fix(webactor): report a lost message instead of dropping it silently

### DIFF
--- a/.changeset/violet-pears-repeat.md
+++ b/.changeset/violet-pears-repeat.md
@@ -1,0 +1,13 @@
+---
+'webactor': minor
+---
+
+Report a lost message instead of dropping it silently.
+
+A message that a transport refuses now produces a `messageerror` envelope carrying the transport's own error, so it stops being invisible. When the failed envelope was routed — a response, a channel handshake — the report inherits that route and travels to whoever was waiting, and a pending `request` rejects with the real cause instead of retrying until its `abortSignal` fires. Transports implementing the platform `messageerror` event now feed it into the same channel, so a failed deserialization reaches the endpoint as well.
+
+Keep it distinct from `error`: an `error` envelope still means the endpoint itself died and is what supervisors act on, while `messageerror` says one message was lost and the endpoint is fine.
+
+New public surface: `EnvelopeType.MessageError`, the `MessageErrorEnvelope` type, and the `Reasons.Undeliverable` / `Reasons.Undeserializable` fallbacks.
+
+Also fixes a listener in an envelope emitter being able to swallow a whole dispatch: a throwing listener used to reject the internal dispatch promise as an unhandled rejection and skip every listener after it. It is now rethrown as an ordinary uncaught error, exactly like a throwing DOM event listener, and the remaining listeners still receive the envelope.

--- a/documentation.md
+++ b/documentation.md
@@ -84,7 +84,7 @@ To run outside the browser (Node, Vitest) inject polyfills via [providers](#13-e
 Every message is wrapped in an **Envelope**:
 
 ```ts
-type EnvelopeTypes = 'error' | 'close' | 'message';
+type EnvelopeTypes = 'error' | 'close' | 'message' | 'messageerror';
 
 type Envelope<T> = {
     readonly type: EnvelopeTypes;
@@ -97,7 +97,7 @@ type Envelope<T> = {
 };
 ```
 
-- `type` — one of `EnvelopeType.Message` (`'message'`), `EnvelopeType.Close` (`'close'`), `EnvelopeType.Error` (`'error'`).
+- `type` — one of `EnvelopeType.Message` (`'message'`), `EnvelopeType.Close` (`'close'`), `EnvelopeType.Error` (`'error'`), `EnvelopeType.MessageError` (`'messageerror'`).
 - `data` — your payload. Must be structured-cloneable when crossing a worker boundary (see [Delivery semantics](#5-delivery-semantics)).
 - `transferable` — objects to transfer rather than clone (see [Transferables](#12-transferables)).
 - `__route` / `__checkpoints` — the routing breadcrumbs. You normally never touch these; the library reads and rewrites them as an envelope hops across connections. They're what make request/response and channels work across an arbitrary mesh. See [the routing model](#6-connecting-actors--the-routing-model).
@@ -221,6 +221,41 @@ Understand these three rules — they prevent 90% of "why didn't my message arri
 
 3. **Order is preserved per connection.** Messages sent over one connection arrive in the order they were sent.
 
+### When a message does not make it
+
+A failure of a single message is reported as a `messageerror` envelope carrying an `Error`. Keep it distinct
+from `error`: an `error` envelope means the endpoint itself died and is what supervisors act on to decide a
+restart, while a `messageerror` says one message was lost and the endpoint is fine.
+
+```ts
+ctx.addEventListener('messageerror', (envelope) => {
+    console.warn('a message was lost:', envelope.data.message);
+});
+```
+
+Two causes produce it:
+
+- **Undeliverable** — a transport refused the payload on the way out, for example an unserializable
+  transferable or a dead port. The `Error` is the one the transport threw; when the transport threw a
+  non-error, its message is `Reasons.Undeliverable`.
+- **Undeserializable** — a transport implementing the platform `messageerror` event reported that an
+  incoming message could not be deserialized, with `Reasons.Undeserializable` as the message. Transports
+  without the event — Electron's `MessagePortMain`, for one — simply never fire it, and such a message stays
+  silently lost.
+
+**Where the report goes.** A refused payload does not mean a broken link: an `Error` travels where a
+transferable could not. So when the failed envelope was **routed** — a response, a channel handshake, in
+short something with a party waiting on the far side — the report inherits that route and continues in the
+same direction until it reaches them. A pending [`request`](#7-request--response) matching that route rejects
+immediately with the original error instead of retrying into a wall.
+
+Everything else is only meaningful locally, so it is delivered to the nearest endpoint and relayed no
+further: a report with no route, and every `Undeserializable`. If even the report cannot be handed over, it
+goes to `loggerProvider.error` — at that point there is nobody left to tell.
+
+A throwing listener is a separate matter: it never reaches the peer at all. It is rethrown as an uncaught
+error, exactly like a throwing DOM event listener, and the remaining listeners still receive the envelope.
+
 ---
 
 ## 6. Connecting actors & the routing model
@@ -303,7 +338,7 @@ function request(
 
 - Sends the message tagged with a `channelId`, then **re-sends it every `retryDelay` ms until a matching response arrives.** This makes requests robust to a responder that isn't wired up yet — but see the note below.
 - Resolves with the **response envelope** (read `res.data`).
-- **Rejects** if the response payload is an `Error`, or when `abortSignal` aborts — including a signal that is **already aborted** at call time (the request is then never sent).
+- **Rejects** if the response payload is an `Error`, if a hop reports the response as undeliverable (see [When a message does not make it](#when-a-message-does-not-make-it)), or when `abortSignal` aborts — including a signal that is **already aborted** at call time (the request is then never sent).
 
 ```ts
 const res = await request(server, { type: 'getUser', id: 42 });
@@ -663,11 +698,13 @@ const Reasons = {
     Close: 'Close',
     Restart: 'Restart',
     LostConnection: 'Lost connection',
+    Undeliverable: 'Undeliverable',
+    Undeserializable: 'Undeserializable',
 };
 const $Aborted: unique symbol;
 ```
 
-Standard close/abort reasons. `LostConnection` is emitted by channels and the worker supervisor when a peer disappears. `$Aborted` is an internal sentinel used to swallow abort-caused rejections.
+Standard close/abort reasons. `LostConnection` is emitted by channels and the worker supervisor when a peer disappears. `Undeliverable` and `Undeserializable` are the fallback messages of a `messageerror` envelope (see [Delivery semantics](#5-delivery-semantics)). `$Aborted` is an internal sentinel used to swallow abort-caused rejections.
 
 ---
 
@@ -721,7 +758,7 @@ Standard close/abort reasons. `LostConnection` is emitted by channels and the wo
 | `shallowCopyEnvelope`   | `(v) => Envelope`                                   |
 | `createEnvelopeChannel` | `() => { port1, port2 }`                            |
 | `createEnvelopeEmitter` | `() => EnvelopeEmitter`                             |
-| `EnvelopeType`          | `{ Error, Close, Message }`                         |
+| `EnvelopeType`          | `{ Error, Close, Message, MessageError }`                         |
 
 ### Providers & constants
 
@@ -772,7 +809,7 @@ Open a channel, then push many messages over it; close it (or let `LostConnectio
 
 **`connectActors` doesn't forward my `close`/`error`.** By design — only `message` is forwarded by default. Use `connectTransmitters(a, b, [EnvelopeType.Message, EnvelopeType.Close, EnvelopeType.Error])`.
 
-**`request` hangs forever.** No responder is wired up, or its route doesn't reach back. `request` retries indefinitely — always pass an `abortSignal`. Also confirm both actors are `launch()`ed and connected.
+**`request` hangs forever.** No responder is wired up, or its route doesn't reach back. `request` retries indefinitely — always pass an `abortSignal`. Also confirm both actors are `launch()`ed and connected. A responder that answers with something a transport cannot clone does **not** hang: the request rejects with the transport's own error (see [When a message does not make it](#when-a-message-does-not-make-it)).
 
 **Channels / worker supervisor throw in Node.** They need `navigator.locks`. Set `locksProvider.delegate` to a polyfill.
 

--- a/packages/webactor/src/connectTransmitters.ts
+++ b/packages/webactor/src/connectTransmitters.ts
@@ -1,6 +1,9 @@
 import { devtools, handleBridgeEnvelope, isBridgeEnvelope, observeRemoteTransmitter } from './devtools/internal';
-import { AnyEnvelope, EnvelopeType, isEnvelope, shallowCopyEnvelope } from './envelope';
+import { AnyEnvelope, createEnvelope, EnvelopeType, EnvelopeTypes, isEnvelope, shallowCopyEnvelope } from './envelope';
+import { loggerProvider } from './providers';
+import { Reasons } from './reason';
 import { AnyData, EventType, Transmitter } from './types';
+import { reasonToError } from './utils/common';
 import { createRoute, extendRoute, isRoutedEnvelope, reduceRoute, routeEndsWith } from './utils/route';
 import { getTransmitterName, on, post } from './utils/transmitter';
 
@@ -33,7 +36,23 @@ function resubscribe(source: Transmitter, target: Transmitter, connectedTypes: T
     const disposes = connectedTypes.map((subscribedType) =>
         on(source, subscribedType, createReposter(subscribedType, connectedTypes, source, target)),
     );
+    disposes.push(on(source, EnvelopeType.MessageError, createMessageErrorReposter(source, target)));
     return () => disposes.forEach((off) => off());
+}
+
+function createMessageErrorReposter(source: Transmitter, target: Transmitter) {
+    const sourceName = getTransmitterName(source);
+    const targetName = getTransmitterName(target);
+    return function repostMessageError(data: AnyData) {
+        if (!isEnvelope(data)) {
+            const report = createEnvelope(EnvelopeType.MessageError, reasonToError(data, Reasons.Undeserializable));
+            safePost(source, target, EnvelopeType.MessageError, report);
+            return;
+        }
+        if (!isRoutedEnvelope(data)) return; // addressed to this endpoint and already there, nothing to relay
+        const envelope = processEnvelope(data, sourceName, targetName);
+        if (envelope) safePost(source, target, envelope.type, envelope);
+    };
 }
 
 function createReposter(subscribedType: Type, connectedTypes: Type[], source: Transmitter, target: Transmitter) {
@@ -46,12 +65,50 @@ function createReposter(subscribedType: Type, connectedTypes: Type[], source: Tr
                 return;
             }
             const envelope = processEnvelope(data, sourceName, targetName);
-            if (devtools.active) devtools.message(source, target, envelope ?? data, envelope !== undefined);
-            if (envelope) post(target, envelope.type, envelope);
+            if (envelope) safePost(source, target, envelope.type, envelope);
         } else {
-            post(target, subscribedType, data);
+            safePost(source, target, subscribedType, createEnvelope(subscribedType, data));
         }
     };
+}
+
+/** An envelope the router did not address to this link never happened here, so only real hops are recorded. */
+function safePost(source: Transmitter, target: Transmitter, type: EnvelopeTypes, envelope: AnyEnvelope): void {
+    try {
+        post(target, type, envelope);
+        devtools.message(source, target, envelope, true);
+    } catch (error) {
+        devtools.message(source, target, envelope, false);
+        reportUndelivered(source, target, type, envelope, error);
+    }
+}
+
+function reportUndelivered(
+    source: Transmitter,
+    target: Transmitter,
+    type: EnvelopeTypes,
+    failed: AnyEnvelope,
+    error: unknown,
+): void {
+    if (type === EnvelopeType.MessageError) {
+        loggerProvider.error(error);
+        return;
+    }
+
+    const route = isRoutedEnvelope(failed) ? failed.__route : undefined;
+    const report = createEnvelope(EnvelopeType.MessageError, reasonToError(error, Reasons.Undeliverable), undefined, {
+        route,
+    });
+
+    if (route === undefined) {
+        try {
+            post(source, EnvelopeType.MessageError, report);
+        } catch (reportError) {
+            loggerProvider.error(reportError);
+        }
+    } else {
+        safePost(source, target, EnvelopeType.MessageError, report);
+    }
 }
 
 function processEnvelope(envelope: AnyEnvelope, sourceName: string, targetName: string) {

--- a/packages/webactor/src/createEnvelopeEmitter.ts
+++ b/packages/webactor/src/createEnvelopeEmitter.ts
@@ -1,6 +1,13 @@
 import { AnyEnvelope, createEnvelope, Envelope, EnvelopeTypes, isEnvelope } from './envelope';
 import { AnyData, EnvelopeEmitter, EventType, TransferableOptions } from './types';
 
+/** Dispatch is asynchronous, so a listener failure cannot reach the sender: rethrow it as an uncaught error. */
+function rethrow(error: unknown): void {
+    queueMicrotask(() => {
+        throw error;
+    });
+}
+
 export function createEnvelopeEmitter<T extends AnyData>(): EnvelopeEmitter<Envelope<T>> {
     const callbacksRecord: Map<EnvelopeTypes, Set<(event: any) => unknown>> = new Map();
 
@@ -21,7 +28,13 @@ export function createEnvelopeEmitter<T extends AnyData>(): EnvelopeEmitter<Enve
         void Promise.resolve().then(() => {
             if (!callbacksRecord.has(envelope.type)) return;
             for (let callback of callbacksRecord.get(envelope.type)!) {
-                callback(envelope);
+                // A throwing listener must neither reject this dispatch promise nor skip the remaining listeners
+                try {
+                    const result = callback(envelope);
+                    if (result instanceof Promise) result.catch(rethrow);
+                } catch (error) {
+                    rethrow(error);
+                }
             }
         });
     }

--- a/packages/webactor/src/devtools/bridge.ts
+++ b/packages/webactor/src/devtools/bridge.ts
@@ -171,8 +171,6 @@ export function handleBridgeEnvelope(transmitter: object, envelope: AnyEnvelope)
 
     const state = states.get(transmitter);
     if (state !== undefined) {
-        // Both ends attached out over the same port, which happens whenever a second page connects to
-        // an already-active SharedWorker. The root wins: it is the only end that can deliver anywhere.
         if (state.direction === 'in') return;
         if (!data.root || devtools.hasLocalSink()) return;
         state.detach();

--- a/packages/webactor/src/envelope.ts
+++ b/packages/webactor/src/envelope.ts
@@ -6,6 +6,7 @@ export const EnvelopeType = {
     Error: 'error',
     Close: 'close',
     Message: 'message',
+    MessageError: 'messageerror',
 } as const;
 
 export type EnvelopeTypes = ValueOf<typeof EnvelopeType>;
@@ -21,6 +22,7 @@ export type Envelope<T> = {
 
 export type AnyEnvelope = Envelope<AnyData>;
 export type ErrorEnvelope = Envelope<AnyData>;
+export type MessageErrorEnvelope = Envelope<Error>;
 export type CloseEnvelope = Envelope<{ reason?: Reason; source?: AnyData }>;
 
 export function isEnvelope(v: unknown): v is AnyEnvelope {

--- a/packages/webactor/src/reason.ts
+++ b/packages/webactor/src/reason.ts
@@ -6,5 +6,7 @@ export const Reasons = {
     Close: 'Close',
     Restart: 'Restart',
     LostConnection: 'Lost connection',
+    Undeliverable: 'Undeliverable',
+    Undeserializable: 'Undeserializable',
 };
 export const $Aborted = Symbol('Aborted');

--- a/packages/webactor/src/request/request.ts
+++ b/packages/webactor/src/request/request.ts
@@ -1,4 +1,4 @@
-import { AnyEnvelope, createEnvelope, isEnvelope } from '../envelope';
+import { AnyEnvelope, createEnvelope, EnvelopeType, isEnvelope } from '../envelope';
 import { intervalProvider } from '../providers';
 import { Reasons } from '../reason';
 import { EventType, Transmitter, type AnyData, type TransferableOptions } from '../types';
@@ -38,17 +38,23 @@ export async function request(
             () => post(target, envelope.type, envelope),
             options?.retryDelay ?? 500,
         );
-        const off = on(target, 'message', (envelope) => {
+        const settle = (envelope: AnyData) => {
             if (!isEnvelope(envelope)) return;
             if (envelope.__route !== chnanelId) return;
             if (envelope.data instanceof Error) reject(envelope.data);
-            else resolve(envelope);
+            else if (envelope.type === EnvelopeType.MessageError) {
+                reject(reasonToError(envelope.data, Reasons.Undeliverable));
+            } else resolve(envelope);
             onFinally();
-        });
+        };
+        // A native port delivers every envelope as a message event, an emitter dispatches by envelope type
+        const offMessage = on(target, EventType.Message, settle);
+        const offMesageError = on(target, EnvelopeType.MessageError, settle);
         const onFinally = () => {
             options?.abortSignal?.removeEventListener('abort', onAbort);
             intervalProvider.clearInterval(retryIntervalId);
-            off();
+            offMessage();
+            offMesageError();
         };
 
         post(target, envelope.type, envelope);

--- a/packages/webactor/src/types.ts
+++ b/packages/webactor/src/types.ts
@@ -1,4 +1,4 @@
-import { AnyEnvelope, CloseEnvelope, Envelope, EnvelopeType, ErrorEnvelope } from './envelope';
+import { AnyEnvelope, CloseEnvelope, Envelope, EnvelopeType, ErrorEnvelope, MessageErrorEnvelope } from './envelope';
 import { Reason } from './reason';
 
 export type ValueOf<T> = T[keyof T];
@@ -57,6 +57,7 @@ export interface EnvelopeListener<T extends AnyEnvelope> {
     (type: typeof EnvelopeType.Close, callback: (envelope: CloseEnvelope) => unknown): void;
     (type: typeof EnvelopeType.Error, callback: (envelope: ErrorEnvelope) => unknown): void;
     (type: typeof EnvelopeType.Message, callback: (envelope: T) => unknown): void;
+    (type: typeof EnvelopeType.MessageError, callback: (envelope: MessageErrorEnvelope) => unknown): void;
 }
 export interface EnvelopeListenerLike<T extends AnyEnvelope> {
     start?: () => void;

--- a/packages/webactor/tests/devtools.test.ts
+++ b/packages/webactor/tests/devtools.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { connectActors } from '../src/connectActors';
+import { connectTransmitters } from '../src/connectTransmitters';
 import { createActor } from '../src/createActor';
+import { createEnvelopeChannel } from '../src/createEnvelopePort';
 import { applyActorSupervisor } from '../src/applyActorSupervisor';
 import { createRetranslator } from '../src/createRetranslator';
 import {
@@ -12,7 +14,7 @@ import {
     type DevtoolsEvent,
 } from '../src/devtools';
 import { addSink, devtools } from '../src/devtools/recorder';
-import type { ActorContext } from '../src/types';
+import type { ActorContext, Transmitter } from '../src/types';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -122,7 +124,7 @@ describe('devtools recorder', () => {
         b.close();
     });
 
-    it('marks undelivered envelopes when a route does not match', async () => {
+    it('records nothing for an envelope the router did not address to the link', async () => {
         const session = record();
         disable = session.disable;
 
@@ -136,11 +138,36 @@ describe('devtools recorder', () => {
         await tick();
         flushDevtools();
 
-        const dropped = getDevtoolsSnapshot().messages.filter((message) => !message.delivered);
-        expect(dropped.length).toBeGreaterThan(0);
+        expect(getDevtoolsSnapshot().messages).toHaveLength(0);
 
         a.close();
         b.close();
+    });
+
+    it('marks a message the transport refused as undelivered', async () => {
+        const session = record();
+        disable = session.disable;
+
+        const local = createEnvelopeChannel();
+        const broken = {
+            name: 'broken',
+            postMessage: () => {
+                throw new Error('An object could not be cloned.');
+            },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const disconnect = connectTransmitters(local.port1 as unknown as Transmitter, broken as Transmitter);
+
+        local.port2.postMessage({ payload: 'never arrives' });
+        await tick();
+        flushDevtools();
+
+        const dropped = getDevtoolsSnapshot().messages.filter((message) => !message.delivered);
+        expect(dropped).toHaveLength(1);
+        expect(dropped[0].preview).toEqual({ payload: 'never arrives' });
+
+        disconnect();
     });
 
     it('records retranslator and supervisor kinds with restarts', async () => {

--- a/packages/webactor/tests/envelope-emitter.test.ts
+++ b/packages/webactor/tests/envelope-emitter.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { connectTransmitters } from '../src/connectTransmitters';
+import { createEnvelopeEmitter } from '../src/createEnvelopeEmitter';
+import { createEnvelopeChannel } from '../src/createEnvelopePort';
+import { createEnvelope, EnvelopeType } from '../src/envelope';
+import { loggerProvider } from '../src/providers';
+import { Reasons } from '../src/reason';
+import { request } from '../src/request/request';
+import { response } from '../src/request/response';
+import { Transmitter } from '../src/types';
+import { MockMessageChannel } from './message-channel-mock';
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const settle = async () => {
+    await tick();
+    await tick();
+};
+
+describe('undelivered messages and failing listeners', () => {
+    let uncaught: unknown[];
+    let rejections: unknown[];
+    let logged: unknown[];
+    let ownHandlers: { uncaught: NodeJS.UncaughtExceptionListener; rejection: (reason: unknown) => void };
+    let hostHandlers: NodeJS.UncaughtExceptionListener[];
+
+    beforeEach(() => {
+        uncaught = [];
+        rejections = [];
+        logged = [];
+        loggerProvider.delegate = { error: (...args: unknown[]) => logged.push(args[0]) };
+        ownHandlers = {
+            uncaught: (error: Error) => uncaught.push(error),
+            rejection: (reason: unknown) => rejections.push(reason),
+        };
+        hostHandlers = process.listeners('uncaughtException');
+        process.removeAllListeners('uncaughtException');
+        process.on('uncaughtException', ownHandlers.uncaught);
+        process.on('unhandledRejection', ownHandlers.rejection);
+    });
+
+    afterEach(() => {
+        loggerProvider.delegate = undefined;
+        process.off('uncaughtException', ownHandlers.uncaught);
+        process.off('unhandledRejection', ownHandlers.rejection);
+        for (const handler of hostHandlers) process.on('uncaughtException', handler);
+    });
+
+    it('should keep dispatching to the remaining listeners when one throws', async () => {
+        const emitter = createEnvelopeEmitter();
+        const received: unknown[] = [];
+
+        emitter.addEventListener('message', () => {
+            throw new Error('listener exploded');
+        });
+        emitter.addEventListener('message', (envelope: any) => received.push(envelope.data));
+
+        emitter.postMessage({ hello: 'world' });
+        await settle();
+
+        expect(received).toEqual([{ hello: 'world' }]);
+        expect(rejections).toHaveLength(0);
+        expect(uncaught).toHaveLength(1);
+        expect((uncaught[0] as Error).message).toBe('listener exploded');
+    });
+
+    it('should rethrow a rejected async listener instead of leaving it unhandled', async () => {
+        const emitter = createEnvelopeEmitter();
+
+        emitter.addEventListener('message', async () => {
+            throw new Error('async listener exploded');
+        });
+
+        emitter.postMessage({ hello: 'world' });
+        await settle();
+
+        expect(rejections).toHaveLength(0);
+        expect(uncaught).toHaveLength(1);
+        expect((uncaught[0] as Error).message).toBe('async listener exploded');
+    });
+
+    it('should report an undeliverable envelope back to the sender as messageerror', async () => {
+        const local = createEnvelopeChannel();
+        let attempts = 0;
+        const broken = {
+            name: 'broken',
+            postMessage: () => {
+                attempts += 1;
+                throw new Error('An object could not be cloned.');
+            },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const disconnect = connectTransmitters(local.port1 as unknown as Transmitter, broken as Transmitter);
+
+        const failures: any[] = [];
+        local.port2.addEventListener(EnvelopeType.MessageError, (envelope: any) => failures.push(envelope));
+
+        local.port2.postMessage({ hello: 'world' });
+        await settle();
+
+        expect(uncaught).toHaveLength(0);
+        expect(rejections).toHaveLength(0);
+        expect(failures).toHaveLength(1);
+        expect(failures[0].type).toBe(EnvelopeType.MessageError);
+        expect(failures[0].data).toBeInstanceOf(Error);
+        expect(failures[0].data.message).toBe('An object could not be cloned.');
+        expect(attempts).toBe(1);
+
+        local.port2.postMessage({ hello: 'again' });
+        await settle();
+
+        expect(failures).toHaveLength(2);
+        expect(attempts).toBe(2);
+
+        disconnect();
+    });
+
+    it('should turn a native messageerror into a messageerror envelope for the local endpoint', async () => {
+        const native = new MockMessageChannel();
+        const local = createEnvelopeChannel();
+        const disconnect = connectTransmitters(
+            native.port1 as unknown as Transmitter,
+            local.port1 as unknown as Transmitter,
+        );
+
+        const failures: any[] = [];
+        local.port2.addEventListener(EnvelopeType.MessageError, (envelope: any) => failures.push(envelope));
+
+        native.port1.dispatchEvent(new MessageEvent('messageerror', { data: null }));
+        await settle();
+
+        expect(uncaught).toHaveLength(0);
+        expect(failures).toHaveLength(1);
+        expect(failures[0].type).toBe(EnvelopeType.MessageError);
+        expect(failures[0].data).toBeInstanceOf(Error);
+        expect(failures[0].data.message).toBe(Reasons.Undeserializable);
+
+        disconnect();
+    });
+
+    it('should carry the report along the route so a pending request rejects at once', async () => {
+        const native = new MockMessageChannel();
+        const local = createEnvelopeChannel();
+        const flaky = {
+            name: 'flaky',
+            postMessage: (data: any) => {
+                if (data?.data?.poison === true) throw new Error('An object could not be cloned.');
+                native.port1.postMessage(data);
+            },
+            addEventListener: native.port1.addEventListener,
+            removeEventListener: native.port1.removeEventListener,
+        };
+        const disconnect = connectTransmitters(flaky as Transmitter, local.port1 as unknown as Transmitter);
+
+        local.port2.addEventListener('message', (envelope: any) => {
+            response(local.port2 as unknown as Transmitter, envelope, { poison: true });
+        });
+
+        await expect(request(native.port2 as unknown as Transmitter, { hello: 'world' })).rejects.toThrow(
+            'An object could not be cloned.',
+        );
+        expect(uncaught).toHaveLength(0);
+        expect(logged).toHaveLength(0);
+
+        disconnect();
+    });
+
+    it('should log when even the report cannot be handed over', async () => {
+        const native = new MockMessageChannel();
+        const broken = {
+            name: 'broken',
+            postMessage: () => {
+                throw new Error('port is gone');
+            },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const disconnect = connectTransmitters(native.port1 as unknown as Transmitter, broken as Transmitter);
+
+        native.port1.dispatchEvent(new MessageEvent('messageerror', { data: null }));
+        await settle();
+
+        expect(uncaught).toHaveLength(0);
+        expect(rejections).toHaveLength(0);
+        expect(logged).toHaveLength(1);
+        expect((logged[0] as Error).message).toBe('port is gone');
+
+        disconnect();
+    });
+
+    it('should not relay a messageerror envelope any further', async () => {
+        const native = new MockMessageChannel();
+        const local = createEnvelopeChannel();
+        const disconnect = connectTransmitters(
+            native.port1 as unknown as Transmitter,
+            local.port1 as unknown as Transmitter,
+        );
+
+        const forwarded: any[] = [];
+        native.port2.addEventListener('message', (event: MessageEvent) => forwarded.push(event.data));
+
+        local.port2.postMessage(createEnvelope(EnvelopeType.MessageError, new Error('local only')));
+        await settle();
+
+        expect(forwarded).toHaveLength(0);
+
+        disconnect();
+    });
+
+    it('should fall back to the Undeliverable reason when the target throws a non-error', async () => {
+        const local = createEnvelopeChannel();
+        const broken = {
+            name: 'broken',
+            postMessage: () => {
+                throw undefined;
+            },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const disconnect = connectTransmitters(local.port1 as unknown as Transmitter, broken as Transmitter);
+
+        const failures: any[] = [];
+        local.port2.addEventListener(EnvelopeType.MessageError, (envelope: any) => failures.push(envelope));
+
+        local.port2.postMessage({ hello: 'world' });
+        await settle();
+
+        expect(failures).toHaveLength(1);
+        expect(failures[0].data).toBeInstanceOf(Error);
+        expect(failures[0].data.message).toBe(Reasons.Undeliverable);
+
+        disconnect();
+    });
+});


### PR DESCRIPTION
## Why

An Electron spike hit `openChannel` hanging for its full 4 s timeout with no explanation. The cause was three layers deep, and each layer turned out to be a separate defect.

`connectTransmitters` posts into a target that can throw — a transferable the transport refuses, a dead port. The throw happened inside a promise in `createEnvelopeEmitter`, so it surfaced as an unhandled rejection, aborted the dispatch loop for every listener after it, and left the waiting `request` retrying every 500 ms into a wall until its `abortSignal` fired.

## What changed

**A lost message is now reported, not dropped.** A refused payload produces a `messageerror` envelope carrying the transport's own error.

A refused payload does not mean a broken link — an `Error` travels where a transferable could not. So when the failed envelope was routed (a response, a channel handshake) the report inherits that route and continues towards whoever was waiting, and a pending `request` rejects with the real cause. Everything else is only meaningful locally: it goes to the nearest endpoint and is relayed no further. Failing to hand over the report itself is a dead end with nobody left to tell, so it goes to `loggerProvider.error`.

`error` keeps its meaning — the endpoint died, supervisors act on it to decide a restart. `messageerror` says one message was lost and the endpoint is fine. Collapsing them would make a supervisor restart a healthy actor over one unserializable payload.

Transports implementing the platform `messageerror` event now feed it into the same channel, so a failed deserialization reaches the endpoint as well. Transports without it (Electron's `MessagePortMain`) simply never fire, and such a message stays lost as before.

**A throwing listener can no longer swallow a dispatch.** It is rethrown as an ordinary uncaught error, exactly like a throwing DOM event listener, and the remaining listeners still receive the envelope. Same for a listener returning a rejected promise.

**The devtools `delivered` flag now means what it says.** It used to be recorded before the send was attempted, and an envelope the router did not address to a link was reported as dropped — in a dense network that is N-1 false drops per routed message. Route mismatches are no longer recorded at all, and the flag is set from the outcome of the send.

## New public surface

`EnvelopeType.MessageError`, the `MessageErrorEnvelope` type, `Reasons.Undeliverable` and `Reasons.Undeserializable`. Changeset included, minor.

## Verification

Unit 139/139, webactor e2e 32/32, devtools package 32/32, `tsc` / oxlint / oxfmt clean.

Each fix is covered by a test that was confirmed to fail without it. On the Electron spike the symptom went from `TimeoutError: signal timed out` after four seconds of retries to `Error: An object could not be cloned.` immediately — the real cause crossing the IPC boundary to the waiting renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)