### PR TITLE
fix(webactor): walk an undelivered report back to a caller behind the hop

### DIFF
--- a/.changeset/violet-pears-repeat.md
+++ b/.changeset/violet-pears-repeat.md
@@ -4,7 +4,7 @@
 
 Report a lost message instead of dropping it silently.
 
-A message that a transport refuses now produces a `messageerror` envelope carrying the transport's own error, so it stops being invisible. When the failed envelope was routed — a response, a channel handshake — the report inherits that route and travels to whoever was waiting, and a pending `request` rejects with the real cause instead of retrying until its `abortSignal` fires. Transports implementing the platform `messageerror` event now feed it into the same channel, so a failed deserialization reaches the endpoint as well.
+A message that a transport refuses now produces a `messageerror` envelope carrying the transport's own error, so it stops being invisible. The report is routed to whoever was waiting for the message that failed: forward along its route when the envelope was already routed, such as a response or a channel handshake, and back along its checkpoints when it was still on its way out. Either way a pending `request` rejects with the real cause instead of retrying until its `abortSignal` fires. Transports implementing the platform `messageerror` event now feed it into the same channel, so a failed deserialization reaches the endpoint as well.
 
 Keep it distinct from `error`: an `error` envelope still means the endpoint itself died and is what supervisors act on, while `messageerror` says one message was lost and the endpoint is fine.
 

--- a/documentation.md
+++ b/documentation.md
@@ -244,14 +244,19 @@ Two causes produce it:
   silently lost.
 
 **Where the report goes.** A refused payload does not mean a broken link: an `Error` travels where a
-transferable could not. So when the failed envelope was **routed** — a response, a channel handshake, in
-short something with a party waiting on the far side — the report inherits that route and continues in the
-same direction until it reaches them. A pending [`request`](#7-request--response) matching that route rejects
-immediately with the original error instead of retrying into a wall.
+transferable could not, so the report is routed to whoever was waiting for the message that failed.
 
-Everything else is only meaningful locally, so it is delivered to the nearest endpoint and relayed no
-further: a report with no route, and every `Undeserializable`. If even the report cannot be handed over, it
-goes to `loggerProvider.error` — at that point there is nobody left to tell.
+- The failed envelope was **routed** — a response, a channel handshake — so someone is waiting beyond the
+  target. The report inherits that route and continues in the same direction.
+- The failed envelope was **on its way out** and carries checkpoints, so anyone waiting sits behind the
+  source. The report travels back along those checkpoints minus the hop that just failed.
+
+Either way a pending [`request`](#7-request--response) whose route matches rejects immediately with the
+original error instead of retrying into a wall.
+
+What is left is only meaningful locally and is relayed no further: a report for an envelope with no
+checkpoints at all, and every `Undeserializable`. If even the report cannot be handed over, it goes to
+`loggerProvider.error` — at that point there is nobody left to tell.
 
 A throwing listener is a separate matter: it never reaches the peer at all. It is rethrown as an uncaught
 error, exactly like a throwing DOM event listener, and the remaining listeners still receive the envelope.

--- a/packages/webactor/src/connectTransmitters.ts
+++ b/packages/webactor/src/connectTransmitters.ts
@@ -4,7 +4,14 @@ import { loggerProvider } from './providers';
 import { Reasons } from './reason';
 import { AnyData, EventType, Transmitter } from './types';
 import { reasonToError } from './utils/common';
-import { createRoute, extendRoute, isRoutedEnvelope, reduceRoute, routeEndsWith } from './utils/route';
+import {
+    createRoute,
+    extendRoute,
+    isCheckpointedEnvelope,
+    isRoutedEnvelope,
+    reduceRoute,
+    routeEndsWith,
+} from './utils/route';
 import { getTransmitterName, on, post } from './utils/transmitter';
 
 type Type =
@@ -95,19 +102,25 @@ function reportUndelivered(
         return;
     }
 
-    const route = isRoutedEnvelope(failed) ? failed.__route : undefined;
-    const report = createEnvelope(EnvelopeType.MessageError, reasonToError(error, Reasons.Undeliverable), undefined, {
-        route,
-    });
+    const failure = reasonToError(error, Reasons.Undeliverable);
 
-    if (route === undefined) {
-        try {
-            post(source, EnvelopeType.MessageError, report);
-        } catch (reportError) {
-            loggerProvider.error(reportError);
-        }
-    } else {
+    // A routed envelope has someone waiting beyond the target, so the report keeps going that way
+    if (isRoutedEnvelope(failed)) {
+        const report = createEnvelope(EnvelopeType.MessageError, failure, undefined, { route: failed.__route });
         safePost(source, target, EnvelopeType.MessageError, report);
+        return;
+    }
+
+    // Anyone waiting sits behind the source, and the checkpoints minus this hop are the way back to them
+    const route = isCheckpointedEnvelope(failed)
+        ? reduceRoute(failed.__checkpoints, getTransmitterName(source), getTransmitterName(target))
+        : undefined;
+    const report = createEnvelope(EnvelopeType.MessageError, failure, undefined, { route });
+
+    try {
+        post(source, EnvelopeType.MessageError, report);
+    } catch (reportError) {
+        loggerProvider.error(reportError);
     }
 }
 

--- a/packages/webactor/src/utils/route.ts
+++ b/packages/webactor/src/utils/route.ts
@@ -33,3 +33,7 @@ export function routeEndsWith(route: Route, ...checkpoints: [Checkpoint, Checkpo
 export function isRoutedEnvelope(envelope: AnyEnvelope): envelope is AnyEnvelope & { __route: Route } {
     return envelope.__route !== undefined;
 }
+
+export function isCheckpointedEnvelope(envelope: AnyEnvelope): envelope is AnyEnvelope & { __checkpoints: Route } {
+    return envelope.__checkpoints !== undefined;
+}

--- a/packages/webactor/tests/envelope-emitter.test.ts
+++ b/packages/webactor/tests/envelope-emitter.test.ts
@@ -166,6 +166,33 @@ describe('undelivered messages and failing listeners', () => {
         disconnect();
     });
 
+    it('should walk the report back to a caller sitting behind an intermediate hop', async () => {
+        const caller = createEnvelopeChannel();
+        const middle = createEnvelopeChannel();
+        const broken = {
+            name: 'broken',
+            postMessage: () => {
+                throw new Error('An object could not be cloned.');
+            },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const first = connectTransmitters(
+            caller.port1 as unknown as Transmitter,
+            middle.port1 as unknown as Transmitter,
+        );
+        const second = connectTransmitters(middle.port2 as unknown as Transmitter, broken as Transmitter);
+
+        await expect(request(caller.port2 as unknown as Transmitter, { hello: 'world' })).rejects.toThrow(
+            'An object could not be cloned.',
+        );
+        expect(uncaught).toHaveLength(0);
+        expect(logged).toHaveLength(0);
+
+        first();
+        second();
+    });
+
     it('should log when even the report cannot be handed over', async () => {
         const native = new MockMessageChannel();
         const broken = {


### PR DESCRIPTION
> Stacked on #15 — review that one first. Base will be `main` once #15 lands.

## Why

#15 routes a `messageerror` to whoever was waiting, but only forward. That covers a caller waiting on a **response** — the failed envelope is routed, so the report inherits its route and continues.

It does not cover a caller waiting on a **request**. A request is still on its way out and carries no route, so the report was terminal: only the endpoint adjacent to the failing hop learned about it. A request that failed on a later relay went on retrying every 500 ms until its `abortSignal` fired — the exact symptom #15 set out to remove, just one topology over.

## What changed

The way back is already recorded. An envelope on its way out accumulates the checkpoints of every hop it crossed, and `response` already turns exactly those into a route. The same arithmetic applies here: the checkpoints **minus the hop that just failed** are the way back to the sender.

```
forward   checkpoints  cid → cid/A/B → cid/A/B/B/C   ✗ post to C fails
report    route        cid/A/B                       ← checkpoints minus B→C
back      route        cid/A/B → cid                 usual routeEndsWith / reduceRoute
```

The report lands on the pending `request` with `__route === cid` and rejects it. No new routing machinery — it reuses the mechanism responses already travel on.

`isCheckpointedEnvelope` joins `isRoutedEnvelope` in `utils/route` so the two directions read the same way.

## About the `crossLink` bug I reported earlier

While looking at this I went back to verify the devtools `crossLink` defect I had described, and it does not exist. Measured with a throwaway spec dumping the event stream for `worker-chain`, with and without the recording that supposedly triggered it: identical graphs — 38 nodes, 25 links, 1020 messages, 4 worker threads, 12 cross-thread links — and zero type-filtered drops in that scenario, so the suspect line never even runs there.

The guard in `crossLink` is correct: it deduplicates the two-sided attach, where both threads announce the same pair and one arrives through `ingest`. A collision with a locally inferred link is not constructible, because `identify` builds node ids as `name<threadId-pointerId>` and a remote id cannot be produced locally.

## Verification

Unit 140/140, e2e 32/32, `tsc` / oxlint / oxfmt clean.

The new test drives `caller — middle — broken` and asserts the request rejects with the transport's error. Without the change it hangs for the full ten seconds and fails on timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)