### PR TITLE
fix(webactor): notice a worker that dies before its handshake answers

### DIFF
--- a/.changeset/lucky-otters-listen.md
+++ b/.changeset/lucky-otters-listen.md
@@ -1,0 +1,13 @@
+---
+'webactor': minor
+---
+
+Notice a worker that dies before its handshake answers.
+
+A worker supervisor watches its worker's liveness through a lock whose key it learns from the handshake reply, so the watch can only be armed once that reply arrives. Before it did, the only detector was the worker's own `error` event. A worker that died quietly in that window — killed by the host, or closing itself — left the supervisor holding a dead worker forever: no restart, no error, nothing. A worker that came up but never answered was equally invisible.
+
+`applyWorkerSupervisor` now accepts `getAbortSignal`, a factory consulted once per launch, so the handshake can be bounded the same way every other operation in the library is: `getAbortSignal: () => AbortSignal.timeout(2000)`. It is a factory rather than a plain signal because a supervisor relaunches, and one signal would already be spent by the second worker. Whatever the returned signal aborts with reaches `shouldRetry` as the reason, so an `AbortSignal.timeout` arrives as a `TimeoutError`.
+
+Nothing changes when it is omitted. A deadline tight enough to be useful would misfire on a loaded machine, where a handshake legitimately takes hundreds of milliseconds, so the choice stays with the caller.
+
+A handshake that fails for any reason other than the supervisor's own teardown now reaches the restart decision too. It previously became an unhandled rejection instead, which meant an undeliverable handshake was reported to nobody and restarted nothing.

--- a/packages/webactor/src/worker/applyWorkerSupervisor.ts
+++ b/packages/webactor/src/worker/applyWorkerSupervisor.ts
@@ -21,8 +21,10 @@ export function applyWorkerSupervisor(
     WorkerConstructor: () => Worker,
     {
         shouldRetry,
+        getAbortSignal,
     }: {
         shouldRetry: (reason?: unknown | Reason | Error | ErrorEvent) => boolean | Promise<boolean>;
+        getAbortSignal?: () => undefined | AbortSignal;
     },
 ): Actor {
     const proxy = createEnvelopeChannel();
@@ -52,13 +54,22 @@ export function applyWorkerSupervisor(
                 .catch(catchAbortToSymbol);
         };
 
-        request(messagePort, THREAD_ID_REQUEST, { abortSignal: abortController.signal })
+        const callerSignal = getAbortSignal?.();
+        const handshakeSignal =
+            callerSignal === undefined
+                ? abortController.signal
+                : AbortSignal.any([abortController.signal, callerSignal]);
+
+        request(messagePort, THREAD_ID_REQUEST, { abortSignal: handshakeSignal })
             .then((envelope) => {
                 if (isObject(envelope.data) && isStringField(envelope.data, 'threadId')) {
                     onUnlockThreadId(envelope.data.threadId);
                 }
             })
-            .catch(catchAbortToSymbol);
+            .catch((error) => {
+                if (abortController.signal.aborted) return;
+                decide(error);
+            });
 
         const errorOff = on(worker, 'error', (error) => decide(error));
 

--- a/packages/webactor/tests/worker/supervisor.test.ts
+++ b/packages/webactor/tests/worker/supervisor.test.ts
@@ -294,6 +294,147 @@ describe('Worker Supervisor Tests with Real Workers', () => {
             console.log(`Termination test result: createCount=${createCount}, restartReasons:`, restartReasons);
         });
 
+        it('should detect a worker that dies before the handshake when given an abort signal', async () => {
+            let createCount = 0;
+            const reasons: unknown[] = [];
+
+            const workerConstructor = () => {
+                createCount++;
+                const worker = createWorker();
+                workers.push(worker);
+                if (createCount === 1) worker.terminate();
+                return worker;
+            };
+
+            supervisedActor = applyWorkerSupervisor(workerConstructor, {
+                getAbortSignal: () => AbortSignal.timeout(150),
+                shouldRetry: async (reason) => {
+                    reasons.push(reason);
+                    return false;
+                },
+            });
+
+            supervisedActor.launch();
+
+            await vi.waitFor(() => expect(reasons.length).toBeGreaterThan(0), { timeout: 5000, interval: 10 });
+
+            expect(reasons[0]).toBeInstanceOf(Error);
+            expect(String(reasons[0])).toContain('TimeoutError');
+            expect(createCount).toBe(1);
+        });
+
+        it('should leave a worker that dies before the handshake unnoticed without an abort signal', async () => {
+            let createCount = 0;
+            let decisions = 0;
+
+            const workerConstructor = () => {
+                createCount++;
+                const worker = createWorker();
+                workers.push(worker);
+                if (createCount === 1) worker.terminate();
+                return worker;
+            };
+
+            supervisedActor = applyWorkerSupervisor(workerConstructor, {
+                shouldRetry: async () => {
+                    decisions++;
+                    return false;
+                },
+            });
+
+            supervisedActor.launch();
+            await new Promise((resolve) => setTimeout(resolve, 600));
+
+            expect(decisions).toBe(0);
+            expect(createCount).toBe(1);
+        });
+
+        it('should build a fresh abort signal for every relaunch', async () => {
+            let createCount = 0;
+            let signalCount = 0;
+            const reasons: unknown[] = [];
+
+            const workerConstructor = () => {
+                createCount++;
+                const worker = createWorker();
+                workers.push(worker);
+                if (createCount <= 2) worker.terminate();
+                return worker;
+            };
+
+            supervisedActor = applyWorkerSupervisor(workerConstructor, {
+                getAbortSignal: () => {
+                    signalCount++;
+                    return AbortSignal.timeout(150);
+                },
+                shouldRetry: async (reason) => {
+                    reasons.push(reason);
+                    return reasons.length < 2;
+                },
+            });
+
+            supervisedActor.launch();
+
+            // a single signal would already be spent here, so the second worker would go unwatched
+            await vi.waitFor(() => expect(reasons.length).toBe(2), { timeout: 5000, interval: 10 });
+
+            expect(signalCount).toBe(createCount);
+            expect(createCount).toBe(2);
+        });
+
+        it('should treat a plain abort from the caller as a failed handshake', async () => {
+            let createCount = 0;
+            const reasons: unknown[] = [];
+            const abortController = new AbortController();
+
+            const workerConstructor = () => {
+                createCount++;
+                const worker = createWorker();
+                workers.push(worker);
+                if (createCount === 1) worker.terminate();
+                return worker;
+            };
+
+            supervisedActor = applyWorkerSupervisor(workerConstructor, {
+                getAbortSignal: () => abortController.signal,
+                shouldRetry: async (reason) => {
+                    reasons.push(reason);
+                    return false;
+                },
+            });
+
+            supervisedActor.launch();
+            abortController.abort();
+
+            await vi.waitFor(() => expect(reasons.length).toBeGreaterThan(0), { timeout: 5000, interval: 10 });
+
+            expect(createCount).toBe(1);
+        });
+
+        it('should not ask for a restart decision when the supervisor itself is closed', async () => {
+            let decisions = 0;
+
+            const workerConstructor = () => {
+                const worker = createWorker();
+                workers.push(worker);
+                return worker;
+            };
+
+            supervisedActor = applyWorkerSupervisor(workerConstructor, {
+                getAbortSignal: () => AbortSignal.timeout(5000),
+                shouldRetry: async () => {
+                    decisions++;
+                    return false;
+                },
+            });
+
+            supervisedActor.launch();
+            supervisedActor.close();
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(decisions).toBe(0);
+        });
+
         it('should handle worker that throws error on message', async () => {
             let createCount = 0;
             let messageErrorCount = 0;

--- a/packages/webactor/tests/worker/supervisor.test.ts
+++ b/packages/webactor/tests/worker/supervisor.test.ts
@@ -1,9 +1,9 @@
 import '../locks';
 
 import { Worker } from '@apacheli/web-workers';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Actor } from '../../src/types';
+import { Actor, AnyData } from '../../src/types';
 import { applyWorkerSupervisor } from '../../src/worker/applyWorkerSupervisor';
 
 function createWorker() {
@@ -16,6 +16,10 @@ function createErrorWorker() {
     return new Worker(new URL('./error-worker.mjs', import.meta.url), {
         type: 'module',
     });
+}
+
+function isTaggedData(data: AnyData, type: string) {
+    return typeof data === 'object' && data !== null && 'type' in data && data.type === type;
 }
 
 describe('Worker Supervisor Tests with Real Workers', () => {
@@ -123,7 +127,8 @@ describe('Worker Supervisor Tests with Real Workers', () => {
             });
 
             supervisedActor.launch();
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            await vi.waitFor(() => expect(retryCount).toBeGreaterThanOrEqual(1), { timeout: 5000, interval: 10 });
+            await new Promise((resolve) => setTimeout(resolve, 200));
 
             expect(retryCount).toBe(1);
             expect(createCount).toBe(1);
@@ -223,15 +228,16 @@ describe('Worker Supervisor Tests with Real Workers', () => {
 
             supervisedActor.launch();
 
-            // Wait for error worker to fail and restart cycles
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            await vi.waitFor(
+                () => {
+                    expect(createCount).toBeGreaterThan(1);
+                    expect(restartReasons.length).toBeGreaterThan(0);
+                    expect(workers.length).toBeGreaterThan(1);
+                },
+                { timeout: 5000, interval: 10 },
+            );
 
             console.log(`Final state: createCount=${createCount}, restartReasons:`, restartReasons);
-
-            // Should have created multiple workers due to errors
-            expect(createCount).toBeGreaterThan(1);
-            expect(restartReasons.length).toBeGreaterThan(0);
-            expect(workers.length).toBeGreaterThan(1);
         });
 
         it('should restart worker when terminated manually', async () => {
@@ -243,15 +249,6 @@ describe('Worker Supervisor Tests with Real Workers', () => {
                 console.log(`Creating terminate-test worker #${createCount}`);
                 const worker = createWorker();
                 workers.push(worker);
-
-                // Terminate the first worker after short delay
-                if (createCount === 1) {
-                    setTimeout(() => {
-                        console.log('Manually terminating first worker...');
-                        worker.terminate();
-                    }, 300);
-                }
-
                 return worker;
             };
 
@@ -267,16 +264,34 @@ describe('Worker Supervisor Tests with Real Workers', () => {
                 },
             });
 
+            let pongs = 0;
+            supervisedActor.addEventListener('message', (envelope) => {
+                if (isTaggedData(envelope.data, 'pong')) pongs++;
+            });
+
             supervisedActor.launch();
 
-            // Wait for termination and restart
-            await new Promise((resolve) => setTimeout(resolve, 300));
+            // terminating before the worker has connected leaves nothing for the supervisor to notice
+            await vi.waitFor(
+                () => {
+                    supervisedActor.postMessage({ type: 'ping' });
+                    expect(pongs).toBeGreaterThan(0);
+                },
+                { timeout: 5000, interval: 20 },
+            );
+
+            console.log('Manually terminating first worker...');
+            workers[0].terminate();
+
+            await vi.waitFor(
+                () => {
+                    expect(createCount).toBeGreaterThanOrEqual(2);
+                    expect(workers.length).toBeGreaterThanOrEqual(2);
+                },
+                { timeout: 5000, interval: 10 },
+            );
 
             console.log(`Termination test result: createCount=${createCount}, restartReasons:`, restartReasons);
-
-            // Should have restarted after termination
-            expect(createCount).toBeGreaterThanOrEqual(2);
-            expect(workers.length).toBeGreaterThanOrEqual(2);
         });
 
         it('should handle worker that throws error on message', async () => {


### PR DESCRIPTION
Started from the CI failure on `tests/worker/supervisor.test.ts > should handle async shouldRetry with Promise rejection for real worker` (`AssertionError: expected +0 to be 1`). That turned out to be a flaky test, but tracking down *why* it was flaky uncovered a real gap in `applyWorkerSupervisor`.

## The flaky tests

Three tests raced the worker startup they were meant to observe. Measured with an instrumented probe, the handshake takes **49–66 ms** on an idle machine, against a hard 100 ms sleep — 35–50 ms of slack. A 2–4 core runner with 16 vitest files in parallel blows through that.

Plain repetition does not reproduce it (15/15 pass locally, idle). Shrinking the wait from 100 ms to 40 ms reproduced the exact CI error on the first try.

Fixed by waiting for the condition. Liveness assertions moved into `vi.waitFor`; "no second restart happened" keeps a fixed settle window, which fails open on a slow machine.

The manual-termination test had a second defect that no timeout tolerance could fix: on a slow machine its blind 300 ms timer killed the worker *before* the handshake completed, and the supervisor genuinely never restarts that — see below. It now terminates only after a ping/pong proves the worker is up, so it tests what it claims.

## The gap

Death detection in `applyWorkerSupervisor` has exactly two triggers:

1. `on(worker, 'error', …)`
2. `onUnlock(threadId, …)` — but the lock key is **learned from the handshake reply**, so the watch can only be armed after that reply arrives.

Before that reply, only trigger 1 exists. And the handshake `request` has no deadline of its own: it retries every `retryDelay` forever, and its abort signal is fired only from `close()`, which is only reachable from `decide()`. So a worker dying quietly in the startup window was never noticed — no restart, no error, nothing.

Probed with six scenarios, counting `shouldRetry` calls over a 3 s window:

| | scenario | before | after |
|---|---|---|---|
| A | `terminate()` 15 ms after spawn | **0** | 1 |
| B | control: terminate after ping/pong | 1 | 1 |
| C | worker script fails to load | 1 | 1 |
| D | worker up but never answers handshake | **0** | 1 |
| E | worker calls `self.close()` immediately | **0** | 1 |
| F | top-level `Promise.reject(…)` | 1 | 1 |

Note the asymmetry: *after* the handshake, silent death **is** covered by the lock watch. The library already intends to catch this — it just had a startup blind window. C and F were always caught because they surface as `error` events; E is the realistic production shape of the gap (host kills the worker, or it closes itself).

## The change

`applyWorkerSupervisor` accepts `getAbortSignal`, consulted once per launch:

```ts
applyWorkerSupervisor(WorkerConstructor, {
    shouldRetry,
    getAbortSignal: () => AbortSignal.timeout(2000),
});
```

A factory rather than a plain signal because a supervisor relaunches — one signal would already be spent by the second worker. There is a test pinning that a fresh signal is built per launch.

Nothing changes when it is omitted, and there is a test pinning that too: a deadline tight enough to be useful would misfire on a loaded machine, so the choice stays with the caller.

**Why a signal and not a timeout number.** An earlier revision of this PR added `timeout` to `request` and `openTimeout` to `openChannel`. Both were dropped: measurement showed `AbortSignal.timeout` already bounded the whole of `openChannel` on `main` — both the request for the port *and* the handshake that follows — so those options added ergonomics, not capability. `applyWorkerSupervisor` was the only place with a genuine hole, because its abort controller is internal and callers had no way to reach it. Building the fix on the primitive the rest of the library already takes keeps one way to bound an operation instead of two.

**The `catch` fix is the other half, and it is not cosmetic.** The handshake used `.catch(catchAbortToSymbol)`, which maps aborts to a sentinel and rethrows the rest — so a failure became an unhandled rejection instead of a restart decision. It now distinguishes **by source** rather than by reason shape: only the supervisor's own teardown stays quiet. That distinction matters — with a reason-shape check, a plain `AbortController` from the caller aborts with `AbortError`, is mistaken for teardown, and gets swallowed, leaving the worker unwatched all over again. Verified: swapping the source check for `isAbort` fails the test covering that case.

## Verification

- Unit: 145 pass (was 140).
- Every new test was checked to be load-bearing by reverting the corresponding source change and confirming it fails.
- Probes A, D and E all reach `shouldRetry` with a `TimeoutError` when a signal is supplied, and still reach nobody when it is not.
- All 9 pre-existing tests in the supervisor file pass with worker startup artificially stalled **400 ms and 1500 ms** — 15× the old budget.
- Build (tsc), oxlint, `format:check` clean. e2e 32/32, devtools 32/32.

Three unrelated flakes surfaced while verifying, all in tests this PR does not touch, none reproducible, and all green on `main`: `e2e/tests/devtools-scenarios.spec.ts:394`, `packages/devtools tests/extension.spec.ts:62`, and `packages/devtools tests/panel.spec.ts:397`. The last one failed the DevTools job on CI here and passed on a re-run with no code change; it survives 34 local runs including 4× parallel. It is the same defect class as the tests fixed above — a fixed 600 ms wait for a force-directed layout to settle, then a click at coordinates sampled before the click lands, so the node can drift out from under it on a slow machine. Worth its own fix, separately.

## Left alone, on purpose

In the supervisor's `.then()`, a handshake reply without a string `threadId` still arms no watch and says nothing — permanently blind, silently. Out of scope here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)